### PR TITLE
Refactored http responses

### DIFF
--- a/notary-commons/build.gradle
+++ b/notary-commons/build.gradle
@@ -37,9 +37,6 @@ dependencies {
     // khttp - consume http
     implementation 'khttp:khttp:0.1.0'
 
-    // JSON converter
-    implementation 'com.squareup.moshi:moshi-kotlin:1.5.0'
-
     // for Result
     implementation group: 'com.github.kittinunf.result', name: 'result', version: '1.4.0'
 

--- a/notary-commons/src/main/kotlin/com/d3/commons/model/NotaryExceptionResponse.kt
+++ b/notary-commons/src/main/kotlin/com/d3/commons/model/NotaryExceptionResponse.kt
@@ -15,9 +15,13 @@ class NotaryException(
     val code: NotaryExceptionErrorCode,
     override val message: String?,
     override val cause: Throwable?
-) : RuntimeException(message, cause) {
+) : Exception(message, cause) {
     constructor(code: NotaryExceptionErrorCode, message: String?) : this(code, message, null)
 }
+
+class NotaryV1Exception(
+    override val message: String?
+) : Exception(message)
 
 data class NotaryResponseStatus(var code: NotaryExceptionErrorCode?, var message: String?) {
     // for databind

--- a/notary-commons/src/main/kotlin/com/d3/commons/model/NotaryExceptionResponse.kt
+++ b/notary-commons/src/main/kotlin/com/d3/commons/model/NotaryExceptionResponse.kt
@@ -19,7 +19,7 @@ class NotaryException(
     constructor(code: NotaryExceptionErrorCode, message: String?) : this(code, message, null)
 }
 
-class NotaryV1Exception(
+class OldNotaryException(
     override val message: String?
 ) : Exception(message)
 

--- a/notary-commons/src/main/kotlin/com/d3/commons/model/NotaryExceptionResponse.kt
+++ b/notary-commons/src/main/kotlin/com/d3/commons/model/NotaryExceptionResponse.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright D3 Ledger, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.d3.commons.model
+
+enum class NotaryExceptionErrorCode {
+    OK,
+    WRONG_INPUT,
+    ALREADY_REGISTERED
+}
+
+class NotaryException(
+    val code: NotaryExceptionErrorCode,
+    override val message: String?,
+    override val cause: Throwable?
+) : RuntimeException(message, cause) {
+    constructor(code: NotaryExceptionErrorCode, message: String?) : this(code, message, null)
+}
+
+data class NotaryResponseStatus(var code: NotaryExceptionErrorCode?, var message: String?) {
+    // for databind
+    private constructor() : this(null, null)
+
+    companion object {
+        private const val SUCCESS_MESSAGE = "Success"
+        val SUCCESS = NotaryResponseStatus(NotaryExceptionErrorCode.OK, SUCCESS_MESSAGE)
+    }
+}
+
+open class NotaryGenericResponse(val status: NotaryResponseStatus) {
+    constructor() : this(NotaryResponseStatus.SUCCESS)
+    constructor(code: NotaryExceptionErrorCode, message: String) : this(NotaryResponseStatus(code, message))
+}

--- a/notary-commons/src/main/kotlin/com/d3/commons/registration/RegistrationServiceEndpoint.kt
+++ b/notary-commons/src/main/kotlin/com/d3/commons/registration/RegistrationServiceEndpoint.kt
@@ -121,7 +121,7 @@ class RegistrationServiceEndpoint(
         var reason = ""
         if (name.isNullOrEmpty()) reason = reason.plus("Parameter \"name\" is not specified. ")
         if (domain.isNullOrEmpty()) reason = reason.plus("Parameter \"domain\" is not specified. ")
-        if (pubkey == null || pubkey.length != 32) reason = reason.plus("Parameter \"pubkey\" is invalid.")
+        if (pubkey == null || pubkey.length != 64) reason = reason.plus("Parameter \"pubkey\" is invalid.")
 
         if (reason.isNotEmpty()) {
             throw NotaryException(NotaryExceptionErrorCode.WRONG_INPUT, reason)

--- a/notary-commons/src/main/kotlin/com/d3/commons/registration/RegistrationServiceEndpoint.kt
+++ b/notary-commons/src/main/kotlin/com/d3/commons/registration/RegistrationServiceEndpoint.kt
@@ -8,7 +8,7 @@ package com.d3.commons.registration
 import com.d3.commons.model.NotaryException
 import com.d3.commons.model.NotaryExceptionErrorCode
 import com.d3.commons.model.NotaryGenericResponse
-import com.d3.commons.model.NotaryV1Exception
+import com.d3.commons.model.OldNotaryException
 import com.d3.commons.util.GsonInstance
 import io.ktor.application.call
 import io.ktor.application.install
@@ -61,7 +61,7 @@ class RegistrationServiceEndpoint(
                 exception<NotaryException> { cause ->
                     call.respond(NotaryGenericResponse(cause.code, cause.message ?: ""))
                 }
-                exception<NotaryV1Exception> { cause ->
+                exception<OldNotaryException> { cause ->
                     call.respond(Response(HttpStatusCode.BadRequest, cause.message ?: ""))
                 }
             }
@@ -78,13 +78,13 @@ class RegistrationServiceEndpoint(
                     call.respond(response)
                 }
 
-                post("/v2/users") {
+                post("$V1/users") {
                     val parameters = call.receiveParameters()
                     val response = invokeRegistrationFromParameters(parameters, true)
                     call.respond(response)
                 }
 
-                post("/v2/users/json") {
+                post("$V1/users/json") {
                     val body = call.receive(UserDto::class)
                     val response = invokeRegistrationFromDto(body, true)
                     call.respond(response)
@@ -143,7 +143,7 @@ class RegistrationServiceEndpoint(
     private fun checkV1(name: String?, domain: String?, pubkey: String?) {
         val reason = validateInputs(name, domain, pubkey)
         if (reason.isNotEmpty()) {
-            throw NotaryV1Exception(reason)
+            throw OldNotaryException(reason)
         }
     }
 
@@ -211,6 +211,7 @@ class RegistrationServiceEndpoint(
      */
     companion object : KLogging() {
         const val CLIENT_ID = "clientId"
+        const val V1 = "/v1"
     }
 }
 

--- a/notary-commons/src/main/kotlin/com/d3/commons/registration/RegistrationServiceEndpoint.kt
+++ b/notary-commons/src/main/kotlin/com/d3/commons/registration/RegistrationServiceEndpoint.kt
@@ -121,12 +121,12 @@ class RegistrationServiceEndpoint(
         var reason = ""
         if (name.isNullOrEmpty()) reason = reason.plus("Parameter \"name\" is not specified. ")
         if (domain.isNullOrEmpty()) reason = reason.plus("Parameter \"domain\" is not specified. ")
-        if (pubkey == null) reason = reason.plus("Parameter \"pubkey\" is not specified.")
+        if (pubkey == null || pubkey.length != 32) reason = reason.plus("Parameter \"pubkey\" is invalid.")
 
-        if (name.isNullOrEmpty() || domain.isNullOrEmpty() || pubkey == null) {
+        if (reason.isNotEmpty()) {
             throw NotaryException(NotaryExceptionErrorCode.WRONG_INPUT, reason)
         }
-        registrationStrategy.register(name, domain, pubkey).fold(
+        registrationStrategy.register(name!!, domain!!, pubkey!!).fold(
             { address ->
                 logger.info {
                     "Client $name@$domain was successfully registered with address $address"

--- a/notary-commons/src/main/kotlin/com/d3/commons/registration/RegistrationServiceEndpoint.kt
+++ b/notary-commons/src/main/kotlin/com/d3/commons/registration/RegistrationServiceEndpoint.kt
@@ -132,22 +132,22 @@ class RegistrationServiceEndpoint(
     ): Any {
         logger.info { "Registration invoked with parameters (name = \"$name\", domain = \"$domain\", pubkey = \"$pubkey\"" }
         return if (isNew) {
-            checkV2(name, domain, pubkey)
-            onPostRegistrationV2(name!!, domain!!, pubkey!!)
+            checkNew(name, domain, pubkey)
+            onPostRegistrationNew(name!!, domain!!, pubkey!!)
         } else {
-            checkV1(name, domain, pubkey)
-            onPostRegistrationV1(name!!, domain!!, pubkey!!)
+            checkOld(name, domain, pubkey)
+            onPostRegistrationOld(name!!, domain!!, pubkey!!)
         }
     }
 
-    private fun checkV1(name: String?, domain: String?, pubkey: String?) {
+    private fun checkOld(name: String?, domain: String?, pubkey: String?) {
         val reason = validateInputs(name, domain, pubkey)
         if (reason.isNotEmpty()) {
             throw OldNotaryException(reason)
         }
     }
 
-    private fun checkV2(name: String?, domain: String?, pubkey: String?) {
+    private fun checkNew(name: String?, domain: String?, pubkey: String?) {
         val reason = validateInputs(name, domain, pubkey)
         if (reason.isNotEmpty()) {
             throw NotaryException(NotaryExceptionErrorCode.WRONG_INPUT, reason)
@@ -162,7 +162,7 @@ class RegistrationServiceEndpoint(
         return reason
     }
 
-    private fun onPostRegistrationV2(
+    private fun onPostRegistrationNew(
         name: String,
         domain: String,
         pubkey: String
@@ -181,7 +181,7 @@ class RegistrationServiceEndpoint(
             })
     }
 
-    private fun onPostRegistrationV1(
+    private fun onPostRegistrationOld(
         name: String,
         domain: String,
         pubkey: String

--- a/notary-iroha-integration-test/src/main/kotlin/integration/registration/RegistrationServiceTestEnvironment.kt
+++ b/notary-iroha-integration-test/src/main/kotlin/integration/registration/RegistrationServiceTestEnvironment.kt
@@ -8,6 +8,7 @@ package integration.registration
 import com.d3.commons.model.IrohaCredential
 import com.d3.commons.provider.NotaryClientsProvider
 import com.d3.commons.registration.NotaryRegistrationStrategy
+import com.d3.commons.registration.RegistrationServiceEndpoint.Companion.V1
 import com.d3.commons.registration.RegistrationServiceInitialization
 import com.d3.commons.sidechain.iroha.consumer.IrohaConsumerImpl
 import com.d3.commons.sidechain.iroha.util.IrohaQueryHelper
@@ -70,7 +71,7 @@ class RegistrationServiceTestEnvironment(private val integrationHelper: IrohaInt
         domain: String = D3_DOMAIN
     ): Response {
         return khttp.post(
-            "http://127.0.0.1:${registrationConfig.port}/v2/users",
+            "http://127.0.0.1:${registrationConfig.port}$V1/users",
             data = mapOf("name" to name, "pubkey" to pubkey, "domain" to domain)
         )
     }

--- a/notary-iroha-integration-test/src/main/kotlin/integration/registration/RegistrationServiceTestEnvironment.kt
+++ b/notary-iroha-integration-test/src/main/kotlin/integration/registration/RegistrationServiceTestEnvironment.kt
@@ -70,7 +70,7 @@ class RegistrationServiceTestEnvironment(private val integrationHelper: IrohaInt
         domain: String = D3_DOMAIN
     ): Response {
         return khttp.post(
-            "http://127.0.0.1:${registrationConfig.port}/users",
+            "http://127.0.0.1:${registrationConfig.port}/v2/users",
             data = mapOf("name" to name, "pubkey" to pubkey, "domain" to domain)
         )
     }

--- a/notary-registration/src/main/kotlin/com/d3/commons/registration/NotaryRegistrationStrategy.kt
+++ b/notary-registration/src/main/kotlin/com/d3/commons/registration/NotaryRegistrationStrategy.kt
@@ -6,6 +6,8 @@
 package com.d3.commons.registration
 
 import com.d3.commons.model.D3ErrorException
+import com.d3.commons.model.NotaryException
+import com.d3.commons.model.NotaryExceptionErrorCode
 import com.d3.commons.notary.IrohaCommand
 import com.d3.commons.notary.IrohaOrderedBatch
 import com.d3.commons.notary.IrohaTransaction
@@ -18,7 +20,6 @@ import com.github.kittinunf.result.flatMap
 import com.github.kittinunf.result.map
 import iroha.protocol.Primitive
 import iroha.protocol.TransactionOuterClass
-import jp.co.soramitsu.iroha.java.ErrorResponseException
 import jp.co.soramitsu.iroha.java.Utils
 import mu.KLogging
 import org.springframework.beans.factory.annotation.Qualifier
@@ -53,8 +54,8 @@ class NotaryRegistrationStrategy(
         logger.info("notary registration of client $accountName@$domainId with pubkey $publicKey")
         return queryHelper.isRegistered(accountName, domainId, publicKey).flatMap { registered ->
             if (registered) {
-                logger.info { "client $accountName@$domainId is already registered" }
-                createSuccessResult(accountName, domainId)
+                val msg = "client $accountName@$domainId is already registered"
+                throw NotaryException(NotaryExceptionErrorCode.ALREADY_REGISTERED, msg)
             } else {
                 createRegistrationBatch(accountName, domainId, publicKey).flatMap { batch ->
                     sendBatch(accountName, domainId, batch)

--- a/notary-sora-integration-test/build.gradle
+++ b/notary-sora-integration-test/build.gradle
@@ -29,8 +29,6 @@ dependencies {
 
     implementation 'khttp:khttp:0.1.0'
 
-    implementation 'com.squareup.moshi:moshi-kotlin:1.5.0'
-
     // unit tests
     testImplementation('org.junit.jupiter:junit-jupiter-api:5.2.0')
     testRuntime('org.junit.jupiter:junit-jupiter-engine:5.2.0')

--- a/notary-sora-integration-test/src/integration-test/kotlin/integration/sora/SoraIntegrationTest.kt
+++ b/notary-sora-integration-test/src/integration-test/kotlin/integration/sora/SoraIntegrationTest.kt
@@ -5,6 +5,7 @@
 
 package integration.sora
 
+import com.d3.commons.model.NotaryGenericResponse
 import com.d3.commons.registration.MappingRegistrationResponse
 import com.d3.commons.sidechain.iroha.util.ModelUtil
 import com.d3.commons.util.GsonInstance
@@ -235,11 +236,11 @@ class SoraIntegrationTest {
 
         val res = registrationEnvironment.register(name, pubkey, domain)
 
-        assertEquals(500, res.statusCode)
+        assertEquals(200, res.statusCode)
 
         val response = gsonInstace.fromJson(
             res.jsonObject.toString(),
-            MappingRegistrationResponse::class.java
+            NotaryGenericResponse::class.java
         )!!
 
         assertNotNull(response.status.code)

--- a/notary-sora-integration-test/src/integration-test/kotlin/integration/sora/SoraIntegrationTest.kt
+++ b/notary-sora-integration-test/src/integration-test/kotlin/integration/sora/SoraIntegrationTest.kt
@@ -5,10 +5,11 @@
 
 package integration.sora
 
+import com.d3.commons.registration.MappingRegistrationResponse
 import com.d3.commons.sidechain.iroha.util.ModelUtil
+import com.d3.commons.util.GsonInstance
 import com.d3.commons.util.getRandomString
 import com.d3.commons.util.toHexString
-import com.squareup.moshi.Moshi
 import integration.helper.IrohaIntegrationHelperUtil
 import integration.registration.RegistrationServiceTestEnvironment
 import jp.co.soramitsu.crypto.ed25519.Ed25519Sha3
@@ -37,10 +38,7 @@ class SoraIntegrationTest {
     private val xorAsset = "xor#$domain"
     private val soraClientId = "xor@sora"
 
-    // Moshi adapter for response JSON deserealization
-    val moshiAdapter = Moshi
-        .Builder()
-        .build()!!.adapter(Map::class.java)!!
+    private val gsonInstace = GsonInstance.get()
 
     init {
         GlobalScope.launch {
@@ -210,8 +208,11 @@ class SoraIntegrationTest {
 
         assertEquals(200, res.statusCode)
 
-        val response = moshiAdapter.fromJson(res.jsonObject.toString())!!
-        val actualClientId = response["clientId"]
+        val response = gsonInstace.fromJson(
+            res.jsonObject.toString(),
+            MappingRegistrationResponse::class.java
+        )!!
+        val actualClientId = response.responseMap["clientId"]
         assertEquals("$name@$domain", actualClientId)
 
         // ensure account is created
@@ -236,10 +237,13 @@ class SoraIntegrationTest {
 
         assertEquals(500, res.statusCode)
 
-        val response = moshiAdapter.fromJson(res.jsonObject.toString())!!
+        val response = gsonInstace.fromJson(
+            res.jsonObject.toString(),
+            MappingRegistrationResponse::class.java
+        )!!
 
-        assertNotNull(response["message"])
-        assertNotNull(response["details"])
+        assertNotNull(response.status.code)
+        assertNotNull(response.status.message)
     }
 
     /**


### PR DESCRIPTION
<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * Jenkins builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->


### Description of the Change
Brings changes to the notary registration service http error handling in order to support the following structure:

```
//successful status without payload
{
   "status":{
      "code":"OK",
      "message":"Success"
   }
}

//business error status
{
   "status":{
      "code":"WRONG_USER_STATUS",
      "message":"The user with id did:test:9ae27519491fc0f904d2 has unexpected status REGISTERED"
   }
}

//successful status with payload
{
   "status":{
      "code":"OK",
      "message":"Success"
   },
   "projects":[
      {
         "id":"bb744ef6-855e-4c49-8b1d-ae2893b9f739",
         "name":"Full Length NES Music Cart - Goofy Foot: Power Chiptunes",
         "description":"description",
         "projectLink":"https://www.kickstarter.com/projects/totalradnes/full-length-nes-music-cart-goofy-foot-power-chiptunes?ref=section-homepage-projectcollection-1-tag",
         "imageLink":"https://sora-projects-static-dev.s3.amazonaws.com/a4189f928f00b4401868de514b813a9040ccec230bea1ac012ae592b3aff53d6",
         "fundingTarget":"1000000",
         "fundingCurrent":"1",
         "fundingDeadline":1583988856,
         "status":"OPEN",
         "statusUpdateTime":1583132173,
         "votedFriendsCount":0,
         "votes":"0",
         "favorite":false,
         "unwatched":true,
         "favoriteCount":0,
         "detailedDescription":"detailedDescription",
         "email":"stlavr12@gmail.com",
         "gallery":[],
         "walletAccountId":"sora@sora"
      }
   ]
}
```
Simple versioning is provided as well, in order to use new format a client should use `/v1` prefix
### Usage Examples or Tests *[optional]*

