### PR TITLE
[DOPS-985] Move sora-net docker images to the new registry

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,9 +23,6 @@ pipeline {
           withCredentials([usernamePassword(credentialsId: 'bot-soranet-ro', usernameVariable: 'login', passwordVariable: 'password')]) {
             sh "docker login docker.soramitsu.co.jp -u ${login} -p '${password}'"
           }
-          withCredentials([usernamePassword(credentialsId: 'bot-soramitsu-ro', usernameVariable: 'login', passwordVariable: 'password')]) {
-            sh "docker login docker.soramitsu.co.jp -u ${login} -p '${password}'"
-          }
           withCredentials([usernamePassword(credentialsId: 'nexus-d3-docker', usernameVariable: 'login', passwordVariable: 'password')]) {
             sh "docker login nexus.iroha.tech:19002 -u ${login} -p '${password}'"
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,8 +20,8 @@ pipeline {
 
           DOCKER_NETWORK = "${env.CHANGE_ID}-${env.GIT_COMMIT}-${BUILD_NUMBER}"
           writeFile file: ".env", text: "SUBNET=${DOCKER_NETWORK}"
-          withCredentials([usernamePassword(credentialsId: 'nexus-soramitsu-ro', usernameVariable: 'login', passwordVariable: 'password')]) {
-            sh "docker login nexus.iroha.tech:19004 -u ${login} -p '${password}'"
+          withCredentials([usernamePassword(credentialsId: 'bot-soranet-ro', usernameVariable: 'login', passwordVariable: 'password')]) {
+            sh "docker login docker.soramitsu.co.jp -u ${login} -p '${password}'"
           }
           withCredentials([usernamePassword(credentialsId: 'nexus-d3-docker', usernameVariable: 'login', passwordVariable: 'password')]) {
             sh "docker login nexus.iroha.tech:19002 -u ${login} -p '${password}'"
@@ -92,12 +92,12 @@ pipeline {
       steps {
         script {
           if (env.BRANCH_NAME ==~ /(master|develop|reserved)/ || env.TAG_NAME) {
-                withCredentials([usernamePassword(credentialsId: 'nexus-soramitsu-rw', usernameVariable: 'login', passwordVariable: 'password')]) {
+                withCredentials([usernamePassword(credentialsId: 'bot-soranet-rw', usernameVariable: 'login', passwordVariable: 'password')]) {
                   TAG = env.TAG_NAME ? env.TAG_NAME : env.BRANCH_NAME
                   iC = docker.image("gradle:4.10.2-jdk8-slim")
                   iC.inside(" -e JVM_OPTS='-Xmx3200m' -e TERM='dumb'"+
                   " -v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/tmp"+
-                  " -e DOCKER_REGISTRY_URL='https://nexus.iroha.tech:19004'"+
+                  " -e DOCKER_REGISTRY_URL='https://docker.soramitsu.co.jp'"+
                   " -e DOCKER_REGISTRY_USERNAME='${login}'"+
                   " -e DOCKER_REGISTRY_PASSWORD='${password}'"+
                   " -e TAG='${TAG}'") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,6 +23,9 @@ pipeline {
           withCredentials([usernamePassword(credentialsId: 'bot-soranet-ro', usernameVariable: 'login', passwordVariable: 'password')]) {
             sh "docker login docker.soramitsu.co.jp -u ${login} -p '${password}'"
           }
+          withCredentials([usernamePassword(credentialsId: 'bot-soramitsu-ro', usernameVariable: 'login', passwordVariable: 'password')]) {
+            sh "docker login docker.soramitsu.co.jp -u ${login} -p '${password}'"
+          }
           withCredentials([usernamePassword(credentialsId: 'nexus-d3-docker', usernameVariable: 'login', passwordVariable: 'password')]) {
             sh "docker login nexus.iroha.tech:19002 -u ${login} -p '${password}'"
           }

--- a/deploy/docker-compose-base.yml
+++ b/deploy/docker-compose-base.yml
@@ -40,7 +40,7 @@ services:
       - d3-network
 
   d3-chain-adapter:
-    image: nexus.iroha.tech:19004/soramitsu/chain-adapter:develop
+    image: docker.soramitsu.co.jp/soramitsu/chain-adapter:develop
     container_name: d3-chain-adapter
     restart: on-failure
     depends_on:
@@ -65,7 +65,7 @@ services:
     command: mongod --smallfiles
 
   d3-brvs:
-    image: nexus.iroha.tech:19004/soranet/brvs-core:develop
+    image: docker.soramitsu.co.jp/soranet/brvs-core:develop
     container_name: d3-brvs
     ports:
       - 8080:8080
@@ -83,7 +83,7 @@ services:
     restart: always
 
   data-collector:
-    image: nexus.iroha.tech:19004/soranet/data-collector:develop
+    image: docker.soramitsu.co.jp/soranet/data-collector:develop
     container_name: "data-collector"
     restart: on-failure
     ports:

--- a/deploy/docker-compose-base.yml
+++ b/deploy/docker-compose-base.yml
@@ -40,7 +40,7 @@ services:
       - d3-network
 
   d3-chain-adapter:
-    image: docker.soramitsu.co.jp/soramitsu/chain-adapter:develop
+    image: docker.soramitsu.co.jp/soramitsu/chain-adapter:master
     container_name: d3-chain-adapter
     restart: on-failure
     depends_on:
@@ -65,7 +65,7 @@ services:
     command: mongod --smallfiles
 
   d3-brvs:
-    image: docker.soramitsu.co.jp/soranet/brvs-core:develop
+    image: docker.soramitsu.co.jp/soranet/brvs-core:master
     container_name: d3-brvs
     ports:
       - 8080:8080
@@ -83,7 +83,7 @@ services:
     restart: always
 
   data-collector:
-    image: docker.soramitsu.co.jp/soranet/data-collector:develop
+    image: docker.soramitsu.co.jp/soranet/data-collector:master
     container_name: "data-collector"
     restart: on-failure
     ports:

--- a/deploy/docker-compose-base.yml
+++ b/deploy/docker-compose-base.yml
@@ -40,7 +40,7 @@ services:
       - d3-network
 
   d3-chain-adapter:
-    image: docker.soramitsu.co.jp/soramitsu/chain-adapter:master
+    image: docker.soramitsu.co.jp/soramitsu/chain-adapter:latest
     container_name: d3-chain-adapter
     restart: on-failure
     depends_on:
@@ -65,7 +65,7 @@ services:
     command: mongod --smallfiles
 
   d3-brvs:
-    image: docker.soramitsu.co.jp/soranet/brvs-core:master
+    image: docker.soramitsu.co.jp/soranet/brvs-core:latest
     container_name: d3-brvs
     ports:
       - 8080:8080
@@ -83,7 +83,7 @@ services:
     restart: always
 
   data-collector:
-    image: docker.soramitsu.co.jp/soranet/data-collector:master
+    image: docker.soramitsu.co.jp/soranet/data-collector:latest
     container_name: "data-collector"
     restart: on-failure
     ports:

--- a/deploy/docker-compose-single.yml
+++ b/deploy/docker-compose-single.yml
@@ -5,7 +5,7 @@ services:
 
   # D3 common registration service
   d3-registration:
-    image: nexus.iroha.tech:19004/soranet/notary-registration:${TAG-master}
+    image: docker.soramitsu.co.jp/soranet/notary-registration:${TAG-master}
     container_name: d3-registration
     restart: on-failure
     ports:
@@ -17,7 +17,7 @@ services:
       - d3-network
 
   d3-exchanger:
-    image: nexus.iroha.tech:19004/soranet/exchanger:${TAG-master}
+    image: docker.soramitsu.co.jp/soranet/exchanger:${TAG-master}
     container_name: d3-exchanger
     restart: on-failure
     environment:
@@ -26,7 +26,7 @@ services:
       - d3-network
 
   d3-changelog:
-    image: nexus.iroha.tech:19004/soranet/changelog-endpoint:master
+    image: docker.soramitsu.co.jp/soranet/changelog-endpoint:master
     container_name: d3-changelog
     restart: on-failure
     ports:
@@ -35,7 +35,7 @@ services:
       - d3-network
 
   d3-notifications:
-    image: nexus.iroha.tech:19004/soranet/notifications:${TAG-master}
+    image: docker.soramitsu.co.jp/soranet/notifications:${TAG-master}
     container_name: d3-notifications
     restart: on-failure
     networks:

--- a/deploy/docker-compose-single.yml
+++ b/deploy/docker-compose-single.yml
@@ -25,14 +25,14 @@ services:
     networks:
       - d3-network
 
-  d3-changelog:
-    image: docker.soramitsu.co.jp/soranet/changelog-endpoint:master
-    container_name: d3-changelog
-    restart: on-failure
-    ports:
-      - 9999:9999
-    networks:
-      - d3-network
+  # d3-changelog:
+  #   image: docker.soramitsu.co.jp/soranet/changelog-endpoint:latest
+  #   container_name: d3-changelog
+  #   restart: on-failure
+  #   ports:
+  #     - 9999:9999
+  #   networks:
+  #     - d3-network
 
   d3-notifications:
     image: docker.soramitsu.co.jp/soranet/notifications:${TAG-master}

--- a/deploy/docker-compose-single.yml
+++ b/deploy/docker-compose-single.yml
@@ -25,14 +25,14 @@ services:
     networks:
       - d3-network
 
-  # d3-changelog:
-  #   image: docker.soramitsu.co.jp/soranet/changelog-endpoint:latest
-  #   container_name: d3-changelog
-  #   restart: on-failure
-  #   ports:
-  #     - 9999:9999
-  #   networks:
-  #     - d3-network
+  d3-changelog:
+    image: docker.soramitsu.co.jp/soranet/changelog-endpoint:latest
+    container_name: d3-changelog
+    restart: on-failure
+    ports:
+      - 9999:9999
+    networks:
+      - d3-network
 
   d3-notifications:
     image: docker.soramitsu.co.jp/soranet/notifications:${TAG-master}

--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -9,7 +9,7 @@ services:
       - d3-network
 
   d3-notifications:
-    image: docker.soramitsu.co.jp/soranet/notifications:develop
+    image: docker.soramitsu.co.jp/soranet/notifications:master
     container_name: d3-notifications
     restart: on-failure
     ports:
@@ -23,7 +23,7 @@ services:
       - d3-network
 
   d3-registration:
-    image: docker.soramitsu.co.jp/soranet/notary-registration:develop
+    image: docker.soramitsu.co.jp/soranet/notary-registration:master
     container_name: d3-registration
     restart: on-failure
     ports:
@@ -35,7 +35,7 @@ services:
       - d3-network
 
   sora-event-notification:
-    image: docker.soramitsu.co.jp/soranet/event-notification:develop
+    image: docker.soramitsu.co.jp/soranet/event-notification:master
     container_name: "sora-event-notification"
     restart: on-failure
     ports:

--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -9,7 +9,7 @@ services:
       - d3-network
 
   d3-notifications:
-    image: nexus.iroha.tech:19004/soranet/notifications:develop
+    image: docker.soramitsu.co.jp/soranet/notifications:develop
     container_name: d3-notifications
     restart: on-failure
     ports:
@@ -23,7 +23,7 @@ services:
       - d3-network
 
   d3-registration:
-    image: nexus.iroha.tech:19004/soranet/notary-registration:develop
+    image: docker.soramitsu.co.jp/soranet/notary-registration:develop
     container_name: d3-registration
     restart: on-failure
     ports:
@@ -35,7 +35,7 @@ services:
       - d3-network
 
   sora-event-notification:
-    image: nexus.iroha.tech:19004/soranet/event-notification:develop
+    image: docker.soramitsu.co.jp/soranet/event-notification:develop
     container_name: "sora-event-notification"
     restart: on-failure
     ports:

--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -9,7 +9,7 @@ services:
       - d3-network
 
   d3-notifications:
-    image: docker.soramitsu.co.jp/soranet/notifications:master
+    image: docker.soramitsu.co.jp/soranet/notifications:latest
     container_name: d3-notifications
     restart: on-failure
     ports:
@@ -23,7 +23,7 @@ services:
       - d3-network
 
   d3-registration:
-    image: docker.soramitsu.co.jp/soranet/notary-registration:master
+    image: docker.soramitsu.co.jp/soranet/notary-registration:latest
     container_name: d3-registration
     restart: on-failure
     ports:
@@ -35,7 +35,7 @@ services:
       - d3-network
 
   sora-event-notification:
-    image: docker.soramitsu.co.jp/soranet/event-notification:master
+    image: docker.soramitsu.co.jp/soranet/event-notification:latest
     container_name: "sora-event-notification"
     restart: on-failure
     ports:

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -50,7 +50,7 @@ services:
       - d3-network
 
   d3-chain-adapter:
-    image: nexus.iroha.tech:19004/soramitsu/chain-adapter:develop
+    image: docker.soramitsu.co.jp/soramitsu/chain-adapter:develop
     container_name: d3-chain-adapter
     restart: on-failure
     ports:
@@ -86,7 +86,7 @@ services:
       - d3-network
 
   d3-brvs:
-    image: nexus.iroha.tech:19004/soranet/brvs-core:develop
+    image: docker.soramitsu.co.jp/soranet/brvs-core:develop
     container_name: d3-brvs
     ports:
       - 8080:8080
@@ -109,7 +109,7 @@ services:
     restart: always
 
   data-collector:
-    image: nexus.iroha.tech:19004/soranet/data-collector:develop
+    image: docker.soramitsu.co.jp/soranet/data-collector:develop
     container_name: "data-collector"
     restart: on-failure
     ports:
@@ -132,7 +132,7 @@ services:
       - d3-network
 
   report-service:
-    image: nexus.iroha.tech:19004/soranet/report-service:develop
+    image: docker.soramitsu.co.jp/soranet/report-service:develop
     container_name: "report-service"
     restart: on-failure
     ports:

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -50,7 +50,7 @@ services:
       - d3-network
 
   d3-chain-adapter:
-    image: docker.soramitsu.co.jp/soramitsu/chain-adapter:master
+    image: docker.soramitsu.co.jp/soramitsu/chain-adapter:develop
     container_name: d3-chain-adapter
     restart: on-failure
     ports:
@@ -86,7 +86,7 @@ services:
       - d3-network
 
   d3-brvs:
-    image: docker.soramitsu.co.jp/soranet/brvs-core:master
+    image: docker.soramitsu.co.jp/soranet/brvs-core:develop
     container_name: d3-brvs
     ports:
       - 8080:8080
@@ -102,6 +102,7 @@ services:
       CREDENTIAL_PUBKEY: b9679bbf526a1c936cd1144b56a370d376fa8246b248cd72f952b45a2f20bdad
       CREDENTIAL_PRIVKEY: 56a3c52cd039d9b73a1720052600a20962350b1ea169b4783cefbf87ed99406a
       BILLING_URL: http://data-collector:8080/
+      ACCOUNTS_HOLDER_SETTER: registration_service@d3
     volumes:
       - ../configs/brvs/keys:/config/keys
     networks:
@@ -109,7 +110,7 @@ services:
     restart: always
 
   data-collector:
-    image: docker.soramitsu.co.jp/soranet/data-collector:master
+    image: docker.soramitsu.co.jp/soranet/data-collector:develop
     container_name: "data-collector"
     restart: on-failure
     ports:
@@ -128,6 +129,15 @@ services:
       IROHA_PORT: 50051
       SPRING_DATASOURCE_USERNAME: test
       SPRING_DATASOURCE_PASSWORD: test
+    networks:
+      - d3-network
+
+  dc-postgres:
+    image: postgres
+    container_name: "dc-postgres"
+    environment:
+      POSTGRES_PASSWORD: test
+      POSTGRES_USER: test
     networks:
       - d3-network
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -50,7 +50,7 @@ services:
       - d3-network
 
   d3-chain-adapter:
-    image: docker.soramitsu.co.jp/soramitsu/chain-adapter:develop
+    image: docker.soramitsu.co.jp/soramitsu/chain-adapter:master
     container_name: d3-chain-adapter
     restart: on-failure
     ports:
@@ -86,7 +86,7 @@ services:
       - d3-network
 
   d3-brvs:
-    image: docker.soramitsu.co.jp/soranet/brvs-core:develop
+    image: docker.soramitsu.co.jp/soranet/brvs-core:master
     container_name: d3-brvs
     ports:
       - 8080:8080
@@ -109,7 +109,7 @@ services:
     restart: always
 
   data-collector:
-    image: docker.soramitsu.co.jp/soranet/data-collector:develop
+    image: docker.soramitsu.co.jp/soranet/data-collector:master
     container_name: "data-collector"
     restart: on-failure
     ports:
@@ -128,34 +128,6 @@ services:
       IROHA_PORT: 50051
       SPRING_DATASOURCE_USERNAME: test
       SPRING_DATASOURCE_PASSWORD: test
-    networks:
-      - d3-network
-
-  report-service:
-    image: docker.soramitsu.co.jp/soranet/report-service:develop
-    container_name: "report-service"
-    restart: on-failure
-    ports:
-      - 8090:8090
-      - 19019:9010
-    depends_on:
-      - data-collector
-    env_file:
-      - ../deploy/.env-default-jvm-options
-    environment:
-      POSTGRES_HOST: dc-postgres
-      POSTGRES_DATABASE: postgres
-      SPRING_DATASOURCE_USERNAME: test
-      SPRING_DATASOURCE_PASSWORD: test
-    networks:
-      - d3-network
-
-  dc-postgres:
-    image: postgres
-    container_name: "dc-postgres"
-    environment:
-      POSTGRES_PASSWORD: test
-      POSTGRES_USER: test
     networks:
       - d3-network
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -50,7 +50,7 @@ services:
       - d3-network
 
   d3-chain-adapter:
-    image: docker.soramitsu.co.jp/soramitsu/chain-adapter:develop
+    image: docker.soramitsu.co.jp/soramitsu/chain-adapter:latest
     container_name: d3-chain-adapter
     restart: on-failure
     ports:
@@ -86,7 +86,7 @@ services:
       - d3-network
 
   d3-brvs:
-    image: docker.soramitsu.co.jp/soranet/brvs-core:develop
+    image: docker.soramitsu.co.jp/soranet/brvs-core:latest
     container_name: d3-brvs
     ports:
       - 8080:8080
@@ -110,7 +110,7 @@ services:
     restart: always
 
   data-collector:
-    image: docker.soramitsu.co.jp/soranet/data-collector:develop
+    image: docker.soramitsu.co.jp/soranet/data-collector:latest
     container_name: "data-collector"
     restart: on-failure
     ports:
@@ -127,6 +127,25 @@ services:
       SPRING_RABBITMQ_HOST: d3-rmq
       IROHA_HOST: d3-iroha
       IROHA_PORT: 50051
+      SPRING_DATASOURCE_USERNAME: test
+      SPRING_DATASOURCE_PASSWORD: test
+    networks:
+      - d3-network
+
+  report-service:
+    image: docker.soramitsu.co.jp/soranet/report-service:latest
+    container_name: "report-service"
+    restart: on-failure
+    ports:
+      - 8090:8090
+      - 19019:9010
+    depends_on:
+      - data-collector
+    env_file:
+      - ../deploy/.env-default-jvm-options
+    environment:
+      POSTGRES_HOST: dc-postgres
+      POSTGRES_DATABASE: postgres
       SPRING_DATASOURCE_USERNAME: test
       SPRING_DATASOURCE_PASSWORD: test
     networks:


### PR DESCRIPTION
# Task

[DOPS-985]: Move sora-net docker images to the new registry.

## Changes

1. Harbor registry used.

## Author

Signed-off-by: Dmitriy Creed <creed@soramitsu.co.jp>

[DOPS-985]: https://soramitsu.atlassian.net/browse/DOPS-985