### PR TITLE
[DOPS-985] Move sora-net docker images to the new registry

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,8 +20,8 @@ pipeline {
 
           DOCKER_NETWORK = "${env.CHANGE_ID}-${env.GIT_COMMIT}-${BUILD_NUMBER}"
           writeFile file: ".env", text: "SUBNET=${DOCKER_NETWORK}"
-          withCredentials([usernamePassword(credentialsId: 'nexus-soramitsu-ro', usernameVariable: 'login', passwordVariable: 'password')]) {
-            sh "docker login nexus.iroha.tech:19004 -u ${login} -p '${password}'"
+          withCredentials([usernamePassword(credentialsId: 'bot-soramitsu-ro', usernameVariable: 'login', passwordVariable: 'password')]) {
+            sh "docker login docker.soramitsu.co.jp -u ${login} -p '${password}'"
           }
           withCredentials([usernamePassword(credentialsId: 'nexus-d3-docker', usernameVariable: 'login', passwordVariable: 'password')]) {
             sh "docker login nexus.iroha.tech:19002 -u ${login} -p '${password}'"
@@ -91,12 +91,12 @@ pipeline {
       steps {
         script {
           if (env.BRANCH_NAME ==~ /(master|develop|reserved)/ || env.TAG_NAME) {
-                withCredentials([usernamePassword(credentialsId: 'nexus-soramitsu-rw', usernameVariable: 'login', passwordVariable: 'password')]) {
+                withCredentials([usernamePassword(credentialsId: 'bot-soramitsu-rw', usernameVariable: 'login', passwordVariable: 'password')]) {
                   TAG = env.TAG_NAME ? env.TAG_NAME : env.BRANCH_NAME
                   iC = docker.image("gradle:4.10.2-jdk8-slim")
                   iC.inside(" -e JVM_OPTS='-Xmx3200m' -e TERM='dumb'"+
                   " -v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/tmp"+
-                  " -e DOCKER_REGISTRY_URL='https://nexus.iroha.tech:19004'"+
+                  " -e DOCKER_REGISTRY_URL='https://docker.soramitsu.co.jp'"+
                   " -e DOCKER_REGISTRY_USERNAME='${login}'"+
                   " -e DOCKER_REGISTRY_PASSWORD='${password}'"+
                   " -e TAG='${TAG}'") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,7 @@ pipeline {
 
           DOCKER_NETWORK = "${env.CHANGE_ID}-${env.GIT_COMMIT}-${BUILD_NUMBER}"
           writeFile file: ".env", text: "SUBNET=${DOCKER_NETWORK}"
-          withCredentials([usernamePassword(credentialsId: 'bot-soramitsu-ro', usernameVariable: 'login', passwordVariable: 'password')]) {
+          withCredentials([usernamePassword(credentialsId: 'bot-soranet-ro', usernameVariable: 'login', passwordVariable: 'password')]) {
             sh "docker login docker.soramitsu.co.jp -u ${login} -p '${password}'"
           }
           withCredentials([usernamePassword(credentialsId: 'nexus-d3-docker', usernameVariable: 'login', passwordVariable: 'password')]) {
@@ -91,7 +91,7 @@ pipeline {
       steps {
         script {
           if (env.BRANCH_NAME ==~ /(master|develop|reserved)/ || env.TAG_NAME) {
-                withCredentials([usernamePassword(credentialsId: 'bot-soramitsu-rw', usernameVariable: 'login', passwordVariable: 'password')]) {
+                withCredentials([usernamePassword(credentialsId: 'bot-soranet-rw', usernameVariable: 'login', passwordVariable: 'password')]) {
                   TAG = env.TAG_NAME ? env.TAG_NAME : env.BRANCH_NAME
                   iC = docker.image("gradle:4.10.2-jdk8-slim")
                   iC.inside(" -e JVM_OPTS='-Xmx3200m' -e TERM='dumb'"+

--- a/deploy/docker-compose-base.yml
+++ b/deploy/docker-compose-base.yml
@@ -40,7 +40,7 @@ services:
       - d3-network
 
   d3-chain-adapter:
-    image: nexus.iroha.tech:19004/soramitsu/chain-adapter:develop
+    image: docker.soramitsu.co.jp/soramitsu/chain-adapter:develop
     container_name: d3-chain-adapter
     restart: on-failure
     depends_on:
@@ -65,7 +65,7 @@ services:
     command: mongod --smallfiles
 
   d3-brvs:
-    image: nexus.iroha.tech:19004/soranet/brvs-core:develop
+    image: docker.soramitsu.co.jp/soranet/brvs-core:develop
     container_name: d3-brvs
     ports:
       - 8080:8080
@@ -83,7 +83,7 @@ services:
     restart: always
 
   data-collector:
-    image: nexus.iroha.tech:19004/soranet/data-collector:develop
+    image: docker.soramitsu.co.jp/soranet/data-collector:develop
     container_name: "data-collector"
     restart: on-failure
     ports:

--- a/deploy/docker-compose-single.yml
+++ b/deploy/docker-compose-single.yml
@@ -5,7 +5,7 @@ services:
 
   # D3 common registration service
   d3-registration:
-    image: nexus.iroha.tech:19004/soranet/notary-registration:${TAG-master}
+    image: docker.soramitsu.co.jp/soranet/notary-registration:${TAG-master}
     container_name: d3-registration
     restart: on-failure
     ports:
@@ -17,7 +17,7 @@ services:
       - d3-network
 
   d3-exchanger:
-    image: nexus.iroha.tech:19004/soranet/exchanger:${TAG-master}
+    image: docker.soramitsu.co.jp/soranet/exchanger:${TAG-master}
     container_name: d3-exchanger
     restart: on-failure
     environment:
@@ -26,7 +26,7 @@ services:
       - d3-network
 
   d3-changelog:
-    image: nexus.iroha.tech:19004/soranet/changelog-endpoint:master
+    image: docker.soramitsu.co.jp/soranet/changelog-endpoint:master
     container_name: d3-changelog
     restart: on-failure
     ports:
@@ -35,7 +35,7 @@ services:
       - d3-network
 
   d3-notifications:
-    image: nexus.iroha.tech:19004/soranet/notifications:${TAG-master}
+    image: docker.soramitsu.co.jp/soranet/notifications:${TAG-master}
     container_name: d3-notifications
     restart: on-failure
     networks:

--- a/deploy/docker-compose-single.yml
+++ b/deploy/docker-compose-single.yml
@@ -25,14 +25,14 @@ services:
     networks:
       - d3-network
 
-  d3-changelog:
-    image: docker.soramitsu.co.jp/soranet/changelog-endpoint:master
-    container_name: d3-changelog
-    restart: on-failure
-    ports:
-      - 9999:9999
-    networks:
-      - d3-network
+  # d3-changelog:
+  #   image: docker.soramitsu.co.jp/soranet/changelog-endpoint:master
+  #   container_name: d3-changelog
+  #   restart: on-failure
+  #   ports:
+  #     - 9999:9999
+  #   networks:
+  #     - d3-network
 
   d3-notifications:
     image: docker.soramitsu.co.jp/soranet/notifications:${TAG-master}

--- a/deploy/docker-compose-single.yml
+++ b/deploy/docker-compose-single.yml
@@ -25,14 +25,14 @@ services:
     networks:
       - d3-network
 
-  # d3-changelog:
-  #   image: docker.soramitsu.co.jp/soranet/changelog-endpoint:master
-  #   container_name: d3-changelog
-  #   restart: on-failure
-  #   ports:
-  #     - 9999:9999
-  #   networks:
-  #     - d3-network
+  d3-changelog:
+    image: docker.soramitsu.co.jp/soranet/changelog-endpoint:latest
+    container_name: d3-changelog
+    restart: on-failure
+    ports:
+      - 9999:9999
+    networks:
+      - d3-network
 
   d3-notifications:
     image: docker.soramitsu.co.jp/soranet/notifications:${TAG-master}

--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -9,7 +9,7 @@ services:
       - d3-network
 
   d3-notifications:
-    image: nexus.iroha.tech:19004/soranet/notifications:develop
+    image: docker.soramitsu.co.jp/soranet/notifications:develop
     container_name: d3-notifications
     restart: on-failure
     ports:
@@ -23,7 +23,7 @@ services:
       - d3-network
 
   d3-registration:
-    image: nexus.iroha.tech:19004/soranet/notary-registration:develop
+    image: docker.soramitsu.co.jp/soranet/notary-registration:develop
     container_name: d3-registration
     restart: on-failure
     ports:
@@ -35,7 +35,7 @@ services:
       - d3-network
 
   sora-event-notification:
-    image: nexus.iroha.tech:19004/soranet/event-notification:develop
+    image: docker.soramitsu.co.jp/soranet/event-notification:develop
     container_name: "sora-event-notification"
     restart: on-failure
     ports:

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -132,6 +132,25 @@ services:
     networks:
       - d3-network
 
+  report-service:
+    image: docker.soramitsu.co.jp/soranet/report-service:develop
+    container_name: "report-service"
+    restart: on-failure
+    ports:
+      - 8090:8090
+      - 19019:9010
+    depends_on:
+      - data-collector
+    env_file:
+      - ../deploy/.env-default-jvm-options
+    environment:
+      POSTGRES_HOST: dc-postgres
+      POSTGRES_DATABASE: postgres
+      SPRING_DATASOURCE_USERNAME: test
+      SPRING_DATASOURCE_PASSWORD: test
+    networks:
+      - d3-network
+
   dc-postgres:
     image: postgres
     container_name: "dc-postgres"

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -132,25 +132,6 @@ services:
     networks:
       - d3-network
 
-  report-service:
-    image: docker.soramitsu.co.jp/soranet/report-service:develop
-    container_name: "report-service"
-    restart: on-failure
-    ports:
-      - 8090:8090
-      - 19019:9010
-    depends_on:
-      - data-collector
-    env_file:
-      - ../deploy/.env-default-jvm-options
-    environment:
-      POSTGRES_HOST: dc-postgres
-      POSTGRES_DATABASE: postgres
-      SPRING_DATASOURCE_USERNAME: test
-      SPRING_DATASOURCE_PASSWORD: test
-    networks:
-      - d3-network
-
   dc-postgres:
     image: postgres
     container_name: "dc-postgres"

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -50,7 +50,7 @@ services:
       - d3-network
 
   d3-chain-adapter:
-    image: nexus.iroha.tech:19004/soramitsu/chain-adapter:develop
+    image: docker.soramitsu.co.jp/soramitsu/chain-adapter:develop
     container_name: d3-chain-adapter
     restart: on-failure
     ports:
@@ -86,7 +86,7 @@ services:
       - d3-network
 
   d3-brvs:
-    image: nexus.iroha.tech:19004/soranet/brvs-core:develop
+    image: docker.soramitsu.co.jp/soranet/brvs-core:develop
     container_name: d3-brvs
     ports:
       - 8080:8080
@@ -110,7 +110,7 @@ services:
     restart: always
 
   data-collector:
-    image: nexus.iroha.tech:19004/soranet/data-collector:develop
+    image: docker.soramitsu.co.jp/soranet/data-collector:develop
     container_name: "data-collector"
     restart: on-failure
     ports:
@@ -133,7 +133,7 @@ services:
       - d3-network
 
   report-service:
-    image: nexus.iroha.tech:19004/soranet/report-service:develop
+    image: docker.soramitsu.co.jp/soranet/report-service:develop
     container_name: "report-service"
     restart: on-failure
     ports:


### PR DESCRIPTION
# Task

[DOPS-985]: Move sora-net docker images to the new registry.

## Changes

1. Harbor registry used.

## Author

Signed-off-by: Dmitriy Creed <creed@soramitsu.co.jp>

[DOPS-985]: https://soramitsu.atlassian.net/browse/DOPS-985